### PR TITLE
v1.6.2: Rhythm changes

### DIFF
--- a/Gamep5.js
+++ b/Gamep5.js
@@ -466,7 +466,7 @@ function draw(){
 
             //*/VERSION/
             fill("white");
-            text("v1.6.1", 5, 15);
+            text("v1.6.2", 5, 15);
 
             buttonShow();
             break;


### PR DESCRIPTION
- Red cubes are now synchronized to time instead of frames per seconds on your device by using `getAudioContext().currentTime`, a global float number increasing from zero the moment audio is playable in the browser. As a result, it's easier to get the tempo and to stay on the beat without lag spikes messing up the rhythm.
- Rhythms set for music. Normal is the most calibrated.
- Red boxes move very smooth now with an exception to Firefox browsers with resistFingerprinting enabled. This is more noticable with slower tempo. Red box x coordinates are floats too.
- Low-end devices no longer have red cubes that are severely off the beat. 

Extra things to note / to do:
- This doesn't solve the problem with red cubes  being on the wrong starting point.
- Tempo doesn't change with song yet.
- New bug, not much of an issue. Cubes have a small delay when red cubes are very far from visibility. Easy to fix later conceptually. This is most noteable when having the game in the background for a couple minutes since currentTime value doesn't update in the background.
- Firefox (or similar) Browsers with resistFingerprinting set to true will have red cubes stuck at 10 fps maximum for "security reasons". There are ways around this. Such as checking the value every 1 / 6 times.

Overall this is an improvement in game and is ready to be merged to main branch as of June 28.