### PR TITLE
alpha v1.1.0: Major sync improvements

### DIFF
--- a/Gamep5.js
+++ b/Gamep5.js
@@ -549,7 +549,7 @@ function draw(){
             break;
         //---------------Main Menu------------------
         case 0:
-	    IntermissionThemeSwitch = false;
+            IntermissionThemeSwitch = false;
             buttonBack.hide();
             StartGameButton.hide();
             buttonW.hide();
@@ -573,7 +573,7 @@ function draw(){
 
             //*/Sounds//
             if (MainMenuThemeSwitch === false && !MainMenuTheme.isPlaying()){
-		setup();
+                setup();
                 MainMenuTheme.play();
                 MainMenuTheme.setVolume(0.4);
                 MainMenuTheme.loop();
@@ -807,7 +807,7 @@ function draw(){
             image(MissionSuccessBackground, 0, 0, boardSize, boardSize);
 
             fill('cyan');
-            textSize(50);
+            textSize(45);
             text("M i s s i o n  S u c c e s s", boardSize/25, 100);
 
             //Timers
@@ -2464,19 +2464,19 @@ class Cube{ //The red cube
     // Note: Cubes might be off. Doesn't even seem to follow the tempo if after a tempo change.
 // let sxa = 95; let sxaSound = masterSound; sxaSound.jump(sxa); realMusicTime -= sxa;
     displayLevel1(){
-        this.displayLevelSetup(easySound, this.easyTempo, -22);
+        this.displayLevelSetup(easySound, this.easyTempo, -12);
     }
 
     displayLevel2(){
-        this.displayLevelSetup(normalSound, this.normalTempo, -25);
+        this.displayLevelSetup(normalSound, this.normalTempo, -15);
     }
 
     displayLevel3(){
-        this.displayLevelSetup(hardSound, this.hardTempo, -435);
+        this.displayLevelSetup(hardSound, this.hardTempo, -425);
     }
 
     displayLevel4(){
-        this.displayLevelSetup(masterSound, this.masterTempo, -165);
+        this.displayLevelSetup(masterSound, this.masterTempo, -155);
     }
 }
 //-----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed #35
Fixed #36 ded91ed
In-progress #42 56803f7

Specifically ticked off from #35:
- [x] Red cubes consistently start in the same location. [nick20230710 8dd25b6]
- [x] Tempo changes with song. [nick20230710 f0c6623]
- [x] Calibrate music with extra values. [nick20230710 da13fda]

New pause screen recently:
- [x] Pause screen
- [x] ~~Pause screen synced~~ Pause screen commented out.
The main purpose of this PR is to have synced audio. If the pause screen ruins it all, it's not stable enough and should be commented out. Everything else is good to go though.

PR can wait / be merged with another update. Or it can be a separate update.

- [x] Establish: Merge with or after `v1.0`?
- [x] Version number set. Currently: `alpha v1.1.0`