### PR TITLE
Fixed duplicate audio

### DIFF
--- a/Gamep5.js
+++ b/Gamep5.js
@@ -574,12 +574,10 @@ function draw(){
             //*/Sounds//
             if (MainMenuThemeSwitch === false && !MainMenuTheme.isPlaying()){
                 setup();
-                MainMenuTheme.play();
                 MainMenuTheme.setVolume(0.4);
                 MainMenuTheme.loop();
                 MainMenuThemeSwitch = true;
                 console.log("play")
-// below line might not be needed. git merge v1.0.0 + my PR
                 realStartTime = getAudioContext().currentTime;
             }
             //*/
@@ -1109,10 +1107,9 @@ function intermissionSetup(_level, _button, _sound) {
     _button.show();
     //*/Sounds//
     if (IntermissionThemeSwitch === false && !_sound.isPlaying()){
-    	_sound.setVolume(0.3);
-    	_sound.play();
-	_sound.loop();
-	IntermissionThemeSwitch = true;
+        _sound.setVolume(0.3);
+        _sound.loop(); // implicitly calls .play()
+        IntermissionThemeSwitch = true;
     }
 
     ButtonSound.setVolume(1);


### PR DESCRIPTION
Fixed #5
Likely fixed #47 since Google Chrome, Microsoft Edge and Brave are Chromium-based. Firefox is Gecko-based.

Basically, `.loop()` plays another audio, causing duplicated audio. Not very intuitive from p5js in my opinion.

Tested on Ungoogled Chromium (Google Chromium / Google Chrome), and Brave to no longer have duplicate audio on the start game mode and intermission mode.

Firefox is not affected by this bug, but it has been tested there too in case something breaks.